### PR TITLE
fix(randomChars): will now return the correct number of characters

### DIFF
--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -1,6 +1,17 @@
 import * as Utils from '@tylertech/forge-core/utils/utils';
 
 describe('Utils', () => {
+  describe('randomChars', () => {
+    it('should return default of 5 characters', () => {
+      expect(Utils.randomChars().length).toBe(5);
+    });
+
+    it('should return custom length string', () => {
+      const len = 10;
+      expect(Utils.randomChars(len).length).toBe(len);
+    });
+  });
+
   describe('isDefined', () => {
     it('should return true when defined', () => {
       const test = true;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,7 @@
 /** Generates random characters. Defaults to a length of 5. */
 export function randomChars(length = 5): string {
-  return Math.random().toString(36).substring(2, length);
+  const skip = 2; // Skip the first two chars which are always "0."
+  return Math.random().toString(36).substring(skip, skip + length);
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? Y

## Describe the new behavior?
`randomChars()` will now properly return the correct amount of characters (default is `5`), and tests have been added to validate this.

## Additional information
Fixes #1 
