### PR TITLE
feat(resize): create forge resize observer

### DIFF
--- a/spec/resize-observer.spec.ts
+++ b/spec/resize-observer.spec.ts
@@ -1,0 +1,41 @@
+import { ForgeResizeObserver } from '@tylertech/forge-core';
+
+describe('ForgeResizeObserver', () => {
+  let element: Element;
+
+  beforeEach(() => {
+    ForgeResizeObserver['_targets'].clear();
+    ForgeResizeObserver['_observer']?.disconnect();
+    ForgeResizeObserver['_observer'] = undefined;
+
+    element = document.createElement('div');
+  });
+
+  it('should instantiate the observer when a target is added', () => {
+    ForgeResizeObserver.observe(element, () => { });
+    expect(ForgeResizeObserver['_observer']).toBeDefined();
+  });
+
+  it('should destroy the observer when all targets are removed', () => {
+    ForgeResizeObserver.observe(element, () => { });
+    ForgeResizeObserver.unobserve(element);
+    expect(ForgeResizeObserver['_observer']).toBeUndefined();
+  });
+
+  it('should overwrite the callback of a target that is already observed', () => {
+    const callbackOne = () => { };
+    const callbackTwo = () => { };
+    ForgeResizeObserver.observe(element, callbackOne);
+    ForgeResizeObserver.observe(element, callbackTwo);
+    expect(ForgeResizeObserver['_targets'].size).toBe(1);
+    expect(ForgeResizeObserver['_targets'].get(element)).toBe(callbackTwo);
+  });
+
+  it('should invoke the callback when the target is resized', () => {
+    const spy = jasmine.createSpy();
+    const entry = { target: element } as ResizeObserverEntry;
+    ForgeResizeObserver.observe(element, spy);
+    ForgeResizeObserver['_handleResize']([entry], ForgeResizeObserver['_observer']!);
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from './constants';
 export * from './custom-elements';
 export * from './events';
 export * from './message-list';
+export * from './resize';
 export * from './scroll';
 export * from './services';
 export * from './utils';

--- a/src/resize/index.ts
+++ b/src/resize/index.ts
@@ -1,0 +1,2 @@
+export * from './resize-observer';
+export * from './resize-types';

--- a/src/resize/resize-observer.ts
+++ b/src/resize/resize-observer.ts
@@ -1,0 +1,67 @@
+import { ForgeResizeObserverCallback, IResizeObserverOptions } from './resize-types';
+
+/**
+ * Provides a set of methods for observing and responding to resizing of elements.
+ */
+export abstract class ForgeResizeObserver {
+  private static _observer?: ResizeObserver;
+  private static _targets: Map<Element, ForgeResizeObserverCallback> = new Map();
+  
+  /**
+   * Initiates the observing of a specified `Element`. Calling with an already observed `Element`
+   * overwrites the exisiting observation. It is expected that the consumer will eventually
+   * {@link unobserve} the `Element` to avoid memory leaks.
+   * 
+   * @param target An `Element` reference.
+   * @param callback A function that accepts a `ResizeObserverEntry` for the `Element`.
+   * @param options An options object allowing you to set options for the observation.
+   */
+  public static observe(target: Element, callback: ForgeResizeObserverCallback, options?: IResizeObserverOptions): void {
+    if (ForgeResizeObserver._targets.has(target)) {
+      ForgeResizeObserver._observer?.unobserve(target);
+    }
+  
+    ForgeResizeObserver._targets.set(target, callback);
+    ForgeResizeObserver._countTargets();
+    ForgeResizeObserver._observer?.observe(target, options);
+  }
+  
+  /**
+   * Ends the observing of a specified `Element`.
+   * 
+   * @param target An `Element` reference.
+   */
+  public static unobserve(target: Element): void {
+    ForgeResizeObserver._targets.delete(target);
+    ForgeResizeObserver._observer?.unobserve(target);
+    ForgeResizeObserver._countTargets();
+  }
+  
+  /**
+   * Creates or destroys the `ResizeObserver` based on whether targets exist.
+   */
+  private static _countTargets(): void {
+    if (ForgeResizeObserver._observer) {
+      // If there are no targets destroy the observer
+      if (ForgeResizeObserver._targets.size < 1) {
+        ForgeResizeObserver._observer = undefined;
+      }
+    } else {
+      // If there are targets create the observer
+      if (ForgeResizeObserver._targets.size) {
+        ForgeResizeObserver._observer = new ResizeObserver(ForgeResizeObserver._handleResize);
+      }
+    }
+  }
+  
+  /**
+   * Runs the callback function of targets when they are resized.
+   * 
+   * @param entries An array of `ResizeObserverEntry`s.
+   */
+  private static _handleResize: ResizeObserverCallback = entries => {
+    entries.forEach(entry => {
+      ForgeResizeObserver._targets.get(entry.target)?.(entry);
+    });
+  };
+}

--- a/src/resize/resize-types.ts
+++ b/src/resize/resize-types.ts
@@ -1,0 +1,5 @@
+export type ForgeResizeObserverCallback = (entry: ResizeObserverEntry) => unknown;
+
+export interface IResizeObserverOptions {
+  box: 'content-box' | 'border-box' | 'device-pixel-content-box';
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: Y
- Docs have been added / updated: N/A
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This pull request adds a shared `ResizeObserver` via an abstract class with static members. The class, `ForgeResizeObserver`, benefits performance and ease of use. It exposes two public methods, `observe` and `unobserve`, and instantiates the underlying observer only when needed by tracking target elements and their associated callback functions in a `Map`.
