### PR TITLE
fix(media-observer): add missing features to boolean media feature type

### DIFF
--- a/src/media-observer/media-observer.ts
+++ b/src/media-observer/media-observer.ts
@@ -33,7 +33,7 @@ export abstract class MediaObserver<T> extends Subject<T> {
     return DiscreteMediaObserver.create(feature);
   }
 
-  /** Returns a media oberserver tracking a range feature. */
+  /** Returns a media observer tracking a range feature. */
   /**
    * Returns a new media observer tracking a range feature.
    * @param feature The name of a range media feature.

--- a/src/media-observer/types.ts
+++ b/src/media-observer/types.ts
@@ -35,6 +35,7 @@ export const BOOLEAN_MEDIA_FEATURES = [
   'any-pointer',
   'color',
   'color-index',
+  'dynamic-range',
   'forced-colors',
   'grid',
   'height',
@@ -44,8 +45,11 @@ export const BOOLEAN_MEDIA_FEATURES = [
   'overflow-block',
   'overflow-inline',
   'pointer',
+  'prefers-contrast',
+  'prefers-reduced-motion',
   'scripting',
   'update',
+  'video-dynamic-range',
   'width'
 ] as const;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
A few media features were missing from the boolean media features array and type. This adds them in for simple tracking of off/on values.
