### PR TITLE
fix(media-observer): maintain untouched values in range media observer

### DIFF
--- a/src/media-observer/media-observer.ts
+++ b/src/media-observer/media-observer.ts
@@ -195,17 +195,21 @@ export class RangeMediaObserver extends MediaObserver<string[]> {
       return;
     }
 
-    if (value.matches) {
-      this._valueQueue.push(name);
-    }
-
     if (!this._isAwaitingQueries) {
       setTimeout(() => {
         this.next([...this._valueQueue]);
         this._valueQueue = [];
         this._isAwaitingQueries = false;
       });
+      this._valueQueue = [...this.source];
       this._isAwaitingQueries = true;
+    }
+
+    const index = this._valueQueue.findIndex(queued => queued === name);
+    if (value.matches && index === -1) {
+      this._valueQueue.push(name);
+    } else if (!value.matches && index > -1) {
+      this._valueQueue.splice(index, 1);
     }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This fixes the range media observer to only add or remove touched values during an update. Before it was clearing all values and adding just newly matched queries.
