### PR TITLE
feat(dom-utils): allow for specifying `document` instance in `getActiveElement()`

### DIFF
--- a/src/utils/dom-utils.ts
+++ b/src/utils/dom-utils.ts
@@ -724,12 +724,13 @@ export function deepQuerySelectorAll(rootElement: Element, selectors: string | s
 
 /** 
  * Gets the currently focused element within the document by also traversing shadow roots.
+ * @param {Document} doc The document to get the active element from. Defaults to the current document.
  * @returns {Element}
  */
-export function getActiveElement(): Element {
-  const activeElement = document.activeElement;
+export function getActiveElement(doc = document): Element {
+  const activeElement = doc.activeElement;
 
-  if (!activeElement || activeElement === document.body) {
+  if (!activeElement || activeElement === doc.body) {
     return activeElement as HTMLElement;
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
The `getActiveElement()` utility function was previously using `document` internally, which was causing issues when elements are adopted by other documents and this function is used because `document` was always referring to the document context that the element originated in.

This change adds a new **optional** parameter to this function that defaults to `document` but allows for consumers to provide their own document (such as `element.ownerDocument` for example).
