### PR TITLE
feat(position-utils): add middleware for `:top-layer` support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -884,17 +884,26 @@
       }
     },
     "@floating-ui/core": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.3.tgz",
-      "integrity": "sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+      "requires": {
+        "@floating-ui/utils": "^0.1.3"
+      }
     },
     "@floating-ui/dom": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.4.tgz",
-      "integrity": "sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
       "requires": {
-        "@floating-ui/core": "^0.7.3"
+        "@floating-ui/core": "^1.4.2",
+        "@floating-ui/utils": "^0.1.3"
       }
+    },
+    "@floating-ui/utils": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.4.tgz",
+      "integrity": "sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postversion": "cd dist && npm version $npm_package_version --no-git-tag-version --no-commit-hooks --ignore-scripts"
   },
   "dependencies": {
-    "@floating-ui/dom": "^0.5.0",
+    "@floating-ui/dom": "^1.5.3",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/spec/position-utils.spec.ts
+++ b/spec/position-utils.spec.ts
@@ -1,4 +1,5 @@
-import { IElementPosition, positionElementAsync } from '@tylertech/forge-core';
+import { OffsetOptions } from '@floating-ui/dom';
+import { positionElementAsync } from '@tylertech/forge-core';
 
 interface ITestContext {
   context: ITestPositionUtilsContext;
@@ -144,11 +145,11 @@ describe('position-utils', function() {
     it('should position with offset', async function(this: ITestContext) {
       this.context = setupTestContext();
       const { element, targetElement } = this.context;
-      const offset: IElementPosition = { x: -10, y: -10 };
-      const position = await positionElementAsync({ element, targetElement, placement: 'top', flip: false, shift: false, offset });
+      const offsetOptions: OffsetOptions = { mainAxis: -10, crossAxis: -10 };
+      const position = await positionElementAsync({ element, targetElement, placement: 'top', flip: false, shift: false, offset: true, offsetOptions });
 
-      expect(position.x).withContext('Expected x to be calculated correctly').toBe((targetVals.x + (targetVals.width / 2)) - (elementVals.width / 2) + offset.x);
-      expect(position.y).withContext('Expected y to be calculated correctly').toBe((targetVals.y - elementVals.height) + offset.y);
+      expect(position.x).withContext('Expected x to be calculated correctly').toBe((targetVals.x + (targetVals.width / 2)) - (elementVals.width / 2) + offsetOptions.crossAxis!);
+      expect(position.y).withContext('Expected y to be calculated correctly').toBe((targetVals.y - elementVals.height) - offsetOptions.mainAxis!);
     });
 
     it('should hide when target is not within viewport', async function(this: ITestContext) {

--- a/spec/position-utils.spec.ts
+++ b/spec/position-utils.spec.ts
@@ -1,5 +1,5 @@
 import { OffsetOptions } from '@floating-ui/dom';
-import { positionElementAsync } from '@tylertech/forge-core';
+import { IElementPosition, positionElementAsync } from '@tylertech/forge-core';
 
 interface ITestContext {
   context: ITestPositionUtilsContext;
@@ -152,6 +152,16 @@ describe('position-utils', function() {
       expect(position.y).withContext('Expected y to be calculated correctly').toBe((targetVals.y - elementVals.height) - offsetOptions.mainAxis!);
     });
 
+    it('should position with specific x and y offset', async function(this: ITestContext) {
+      this.context = setupTestContext();
+      const { element, targetElement } = this.context;
+      const offset: IElementPosition = { x: -10, y: -10 };
+      const position = await positionElementAsync({ element, targetElement, placement: 'top', flip: false, shift: false, offset });
+
+      expect(position.x).withContext('Expected x to be calculated correctly').toBe((targetVals.x + (targetVals.width / 2)) - (elementVals.width / 2) + offset.x);
+      expect(position.y).withContext('Expected y to be calculated correctly').toBe((targetVals.y - elementVals.height) + offset.y);
+    });
+  
     it('should hide when target is not within viewport', async function(this: ITestContext) {
       this.context = setupTestContext();
       const { element, targetElement } = this.context;

--- a/src/utils/top-layer-middleware.ts
+++ b/src/utils/top-layer-middleware.ts
@@ -1,0 +1,50 @@
+import type { Middleware } from '@floating-ui/dom';
+import { getContainingBlock } from '@floating-ui/utils/dom';
+
+export const topLayer = (): Middleware => ({
+  name: 'topLayer',
+  async fn({ x, y, elements: { reference, floating } }) {
+    let isTopLayer = false;
+    const referenceEl = reference as HTMLElement;
+    const diffCoords = { x: 0, y: 0 };
+
+    try {
+      isTopLayer = isTopLayer || floating.matches(':popover-open');
+    } catch (error) {}
+    try {
+      isTopLayer = isTopLayer || floating.matches(':open');
+    } catch (error) {}
+    try {
+      isTopLayer = isTopLayer || floating.matches(':modal');
+    } catch (error) {}
+
+    if (!isTopLayer) {
+      return { x, y, data: diffCoords };
+    }
+
+    const containingBlock = getContainingBlock(referenceEl);
+    const inContainingBlock = containingBlock && !isWindow(containingBlock);
+
+    if (isTopLayer && inContainingBlock) {
+      const rect = referenceEl.getBoundingClientRect();
+      diffCoords.x = Math.trunc(rect.x - referenceEl.offsetLeft);
+      diffCoords.y = Math.trunc(rect.y - referenceEl.offsetTop);
+    }
+
+    return {
+      x: x + diffCoords.x,
+      y: y + diffCoords.y,
+      data: diffCoords
+    };
+  }
+});
+
+function isWindow(value): value is Window {
+  return (
+    value &&
+    value.document &&
+    value.location &&
+    value.alert &&
+    value.setInterval
+  );
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Adds support for positioning elements that are in the `:top-layer` if they are within a containing block. The middleware can be applied if the `topLayer` configuration is set to `true`.

This PR also includes updated support for logical offset, while deprecating the specific x and y offset support.
