### PR TITLE
feat(component-utils): prefer `adoptedStyleSheets` if supported, fall back to `<style>` when unsupported while also allowing for `nonce` to be provided now

### DIFF
--- a/src/custom-elements/decorators/custom-element.ts
+++ b/src/custom-elements/decorators/custom-element.ts
@@ -5,6 +5,14 @@ declare global {
   interface Window {
     __forgeFlags__autoDefine: any;
   }
+
+  interface ShadowRoot {
+    adoptedStyleSheets: CSSStyleSheet[];
+  }
+  
+  interface CSSStyleSheet {
+    replaceSync(cssText: string): void;
+  }
 }
 
 export interface ICustomElementConfig {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Adds support for applying styles to a shadow root via the `adoptedStyleSheets()` API. If supported, a new `CSSStyleSheet` instance will be created and adopted into the shadow root, otherwise we fall back to appending a `<style>` element in the shadow DOM.

This will improve performance by reusing the same stylesheet instance all across all instances of a custom element (the styles are cached statically on the custom element constructor object), while also avoiding issues with inline style injection when a CSP is in place. Also, this reduces FOUC issues since the browser does not need to repaint or parse and inject the stylesheet for every instance of the element.

Additionally in regards to CSP, for browsers that do not yet support constructable stylesheets, a new workaround has been provided to give developers a way to provide a `nonce` value for the `<style>` element. The server should set the following on the page before loading any application or library code:
```html
<script>window.forgeNonce = 'nonce-<my base 64 nonce>';</script>
```

This will now inject the `<style>` elements using that nonce value in the `nonce` attribute.

