### PR TITLE
feat(custom-elements): add new `readoptStyles()` helper and adjust how CSS is applied to shadow roots

### DIFF
--- a/src/custom-elements/component-utils.ts
+++ b/src/custom-elements/component-utils.ts
@@ -230,10 +230,10 @@ export function readoptStyles<T extends HTMLElement>(componentInstance: T): void
       !componentInstance.constructor[CUSTOM_ELEMENT_CSS_PROPERTY]) {
     return;
   }
-  const css = componentInstance.constructor[CUSTOM_ELEMENT_CSS_PROPERTY];
+  const cssText = componentInstance.constructor[CUSTOM_ELEMENT_CSS_PROPERTY];
   const context = componentInstance.ownerDocument.defaultView ?? window;
   const sheet = new context.CSSStyleSheet();
-  sheet.replaceSync(css);
+  sheet.replaceSync(cssText);
   componentInstance.shadowRoot.adoptedStyleSheets = [sheet];
 }
 

--- a/src/custom-elements/component-utils.ts
+++ b/src/custom-elements/component-utils.ts
@@ -1,18 +1,20 @@
 import { replaceElement, isArray, removeAllChildren, walkUpUntil } from '../utils';
-
-export const CUSTOM_ELEMENT_STYLES_PROPERTY = '_forgeElementStyles';
-
-/** Whether the browser supports constructable stylesheets */
-export const supportsConstructableStyleSheets = window.ShadowRoot && 'adoptedStyleSheets' in Document.prototype && 'replace' in CSSStyleSheet.prototype;
+import {
+  CUSTOM_ELEMENT_CSS_PROPERTY,
+  CUSTOM_ELEMENT_DEPENDENCIES_PROPERTY,
+  CUSTOM_ELEMENT_NAME_PROPERTY,
+  CUSTOM_ELEMENT_STYLESHEETS_PROPERTY,
+  supportsConstructableStyleSheets
+} from './constants';
 
 /**
  * Recursively defines a component as a custom elements and all of its dependencies.
  * @param component The component to import.
  */
 export function defineCustomElement(component: any): void {
-  tryDefine(component._customElementName, component);
-  if (isArray(component._customElementDependencies)) {
-    defineCustomElements(component._customElementDependencies);
+  tryDefine(component[CUSTOM_ELEMENT_NAME_PROPERTY], component);
+  if (isArray(component[CUSTOM_ELEMENT_DEPENDENCIES_PROPERTY])) {
+    defineCustomElements(component[CUSTOM_ELEMENT_DEPENDENCIES_PROPERTY]);
   }
 }
 
@@ -181,8 +183,8 @@ export function setShadowStyles<T extends HTMLElement>(componentInstance: T, sty
 
   if (!componentInstance.shadowRoot || !styles) {
     if (supportsConstructableStyleSheets) {
-      if (ctor[CUSTOM_ELEMENT_STYLES_PROPERTY]) {
-        ctor[CUSTOM_ELEMENT_STYLES_PROPERTY] = [];
+      if (ctor[CUSTOM_ELEMENT_STYLESHEETS_PROPERTY]) {
+        ctor[CUSTOM_ELEMENT_STYLESHEETS_PROPERTY] = [];
       }
       if (componentInstance.shadowRoot) {
         componentInstance.shadowRoot.adoptedStyleSheets = [];
@@ -194,12 +196,15 @@ export function setShadowStyles<T extends HTMLElement>(componentInstance: T, sty
   styles = styles instanceof Array ? styles : [styles];
 
   if (supportsConstructableStyleSheets) {
-    if (force || !ctor[CUSTOM_ELEMENT_STYLES_PROPERTY]) {
-      const sheet = new CSSStyleSheet();
-      sheet.replaceSync(styles.join(' '));
-      ctor[CUSTOM_ELEMENT_STYLES_PROPERTY] = [sheet];
+    if (force || !ctor[CUSTOM_ELEMENT_STYLESHEETS_PROPERTY]) {
+      const context = componentInstance.ownerDocument.defaultView ?? window;
+      const sheet = new context.CSSStyleSheet();
+      const cssText = styles.join(' ');
+      sheet.replaceSync(cssText);
+      ctor[CUSTOM_ELEMENT_CSS_PROPERTY] = cssText;
+      ctor[CUSTOM_ELEMENT_STYLESHEETS_PROPERTY] = [sheet];
     }
-    componentInstance.shadowRoot.adoptedStyleSheets = ctor[CUSTOM_ELEMENT_STYLES_PROPERTY];
+    componentInstance.shadowRoot.adoptedStyleSheets = ctor[CUSTOM_ELEMENT_STYLESHEETS_PROPERTY];
   } else {
     const styleElement = document.createElement('style');
     // eslint-disable-next-line @typescript-eslint/dot-notation
@@ -213,52 +218,23 @@ export function setShadowStyles<T extends HTMLElement>(componentInstance: T, sty
 }
 
 /**
- * Copies style rules from the provided document stylesheets collection to the provided shadow root stylesheet.
- * @param {Document} fromDocument The document to find the style sheets in.
- * @param {ShadowRoot} shadowRoot The shadow root that contains the stylesheet to copy the rules to.
- * @param {IStyleSheetDescriptor[]} styleSheetDescriptors A collection of style sheet predicates.
- * @param {CSSStyleSheet} shadowStyleSheet The shadow root stylesheet to copy the style rules to.
+ * Reapplies styles to the shadow root of the provided element instance. This function was
+ * intended to be called after an element has been adopted by a new document to reconstruct the
+ * adopted stylesheet instances within the context of the new document.
+ * 
+ * @param componentInstance The component instance to reapply styles to.
  */
-export function provideDocumentStyles(fromDocument: Document, shadowRoot: ShadowRoot, documentStyleSheets: Array<string | IStyleSheetDescriptor>, shadowStyleSheet: CSSStyleSheet): void {
-  if (!shadowStyleSheet) {
+export function readoptStyles<T extends HTMLElement>(componentInstance: T): void {
+  if (!supportsConstructableStyleSheets ||
+      !componentInstance.shadowRoot ||
+      !componentInstance.constructor[CUSTOM_ELEMENT_CSS_PROPERTY]) {
     return;
   }
-
-  const documentSheets: CSSStyleSheet[] = [];
-
-  documentStyleSheets.forEach(sheet => {
-    const sheetName = typeof sheet === 'string' ? sheet : sheet.name;
-    const sheetFilter = (sheet as IStyleSheetDescriptor).selectorFilter;
-    const matchingStyleSheet = _findMatchingStyleSheet(fromDocument.styleSheets, sheetName);
-
-    if (!matchingStyleSheet) {
-      throw new Error(`Could not find stylesheet: ${sheetName}`);
-    }
-
-    let startIndex = shadowStyleSheet.cssRules.length;
-    for (const rule in matchingStyleSheet.cssRules) {
-      if (matchingStyleSheet.cssRules.hasOwnProperty(rule) && matchingStyleSheet.cssRules[rule].cssText && (!sheetFilter || new RegExp(sheetFilter).test((matchingStyleSheet.cssRules[rule] as any).selectorText))) {
-        shadowStyleSheet.insertRule(matchingStyleSheet.cssRules[rule].cssText, startIndex++);
-      }
-    }
-  });
-}
-
-/**
- * Finds a stylesheet by name in the provided stylesheet list.
- * @param styleSheetList The stylesheet list to search.
- * @param sheetName The stylesheet name to find.
- * @returns {CSSStyleSheet | undefined}
- */
-function _findMatchingStyleSheet(styleSheetList: StyleSheetList, sheetName: string): CSSStyleSheet | undefined {
-  for (const prop in styleSheetList) {
-    if (styleSheetList.hasOwnProperty(prop) && styleSheetList[prop].href) {
-      if (new RegExp(sheetName).test(styleSheetList[prop].href as string)) {
-        return styleSheetList[prop] as CSSStyleSheet;
-      }
-    }
-  }
-  return undefined;
+  const css = componentInstance.constructor[CUSTOM_ELEMENT_CSS_PROPERTY];
+  const context = componentInstance.ownerDocument.defaultView ?? window;
+  const sheet = new context.CSSStyleSheet();
+  sheet.replaceSync(css);
+  componentInstance.shadowRoot.adoptedStyleSheets = [sheet];
 }
 
 /**
@@ -353,9 +329,4 @@ export function closestElement(selector: string, startElement: Element): Element
     return found || __closestFrom(((el as Element).getRootNode() as ShadowRoot).host);
   }
   return __closestFrom(startElement);
-}
-
-export interface IStyleSheetDescriptor {
-  name: string;
-  selectorFilter?: string;
 }

--- a/src/custom-elements/constants.ts
+++ b/src/custom-elements/constants.ts
@@ -1,11 +1,11 @@
 export const CUSTOM_ELEMENT_NAME_PROPERTY = Symbol('Forge custom element tag name');
 export const CUSTOM_ELEMENT_DEPENDENCIES_PROPERTY = Symbol('Forge custom element dependencies');
 
-export const CUSTOM_ELEMENT_CSS_PROPERTY = Symbol('Forge element CSS text');
-export const CUSTOM_ELEMENT_STYLESHEETS_PROPERTY = Symbol('Forge element CSSStyleSheet instances');
+export const CUSTOM_ELEMENT_CSS_PROPERTY = Symbol('Forge custom element CSS text');
+export const CUSTOM_ELEMENT_STYLESHEETS_PROPERTY = Symbol('Forge custom element CSSStyleSheet instances');
 
 /** Whether the browser supports constructable stylesheets */
-export const supportsConstructableStyleSheets = window.__forgeFlags__useConstructableStylesheets !== false &&
+export const supportsConstructableStyleSheets = window.__forgeFlags__useConstructableStyleSheets !== false &&
                                                 window.ShadowRoot &&
                                                 'adoptedStyleSheets' in Document.prototype &&
                                                 'replace' in CSSStyleSheet.prototype;

--- a/src/custom-elements/constants.ts
+++ b/src/custom-elements/constants.ts
@@ -1,0 +1,11 @@
+export const CUSTOM_ELEMENT_NAME_PROPERTY = Symbol('Forge custom element tag name');
+export const CUSTOM_ELEMENT_DEPENDENCIES_PROPERTY = Symbol('Forge custom element dependencies');
+
+export const CUSTOM_ELEMENT_CSS_PROPERTY = Symbol('Forge element CSS text');
+export const CUSTOM_ELEMENT_STYLESHEETS_PROPERTY = Symbol('Forge element CSSStyleSheet instances');
+
+/** Whether the browser supports constructable stylesheets */
+export const supportsConstructableStyleSheets = window.__forgeFlags__useConstructableStylesheets !== false &&
+                                                window.ShadowRoot &&
+                                                'adoptedStyleSheets' in Document.prototype &&
+                                                'replace' in CSSStyleSheet.prototype;

--- a/src/custom-elements/decorators/custom-element.ts
+++ b/src/custom-elements/decorators/custom-element.ts
@@ -1,9 +1,11 @@
 import { isFunction } from '../../utils';
 import { defineCustomElement } from '../component-utils';
+import { CUSTOM_ELEMENT_NAME_PROPERTY, CUSTOM_ELEMENT_DEPENDENCIES_PROPERTY } from '../constants';
 
 declare global {
   interface Window {
-    __forgeFlags__autoDefine: any;
+    __forgeFlags__autoDefine: boolean;
+    __forgeFlags__useConstructableStylesheets: boolean;
   }
 
   interface ShadowRoot {
@@ -23,9 +25,6 @@ export interface ICustomElementConfig {
   /** Configures if the element will be automatically defined in the custom element registry. Default is `true` */
   define?: boolean;
 }
-
-export const CUSTOM_ELEMENT_NAME_PROPERTY = '_customElementName';
-export const CUSTOM_ELEMENT_DEPENDENCIES_PROPERTY = '_customElementDependencies';
 
 /**
  * This decorator is intended to be used on classes that extend `HTMLElement` to

--- a/src/custom-elements/decorators/custom-element.ts
+++ b/src/custom-elements/decorators/custom-element.ts
@@ -4,8 +4,8 @@ import { CUSTOM_ELEMENT_NAME_PROPERTY, CUSTOM_ELEMENT_DEPENDENCIES_PROPERTY } fr
 
 declare global {
   interface Window {
-    __forgeFlags__autoDefine: boolean;
-    __forgeFlags__useConstructableStylesheets: boolean;
+    __forgeFlags__autoDefine: boolean | undefined;
+    __forgeFlags__useConstructableStyleSheets: boolean | undefined;
   }
 
   interface ShadowRoot {

--- a/src/custom-elements/index.ts
+++ b/src/custom-elements/index.ts
@@ -1,11 +1,13 @@
 export * from './decorators';
 export * from './component-utils';
+export * from './constants';
 
 export interface ICustomElement extends HTMLElement {
   initializedCallback?: () => void;
   connectedCallback?: () => void;
   disconnectedCallback?: () => void;
   attributeChangedCallback?: (name: string, oldValue: string, newValue: string) => void;
+  adoptedCallback?: () => void;
 }
 
 export interface ICustomElementFoundation {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
Added a new `readoptsStyles()` helper function that is intended to be called from the `adoptedCallback()` of custom elements that are utilizing constructable stylesheets. This helper will re-adopt the CSS text that is applied to the shadow root of that instance when it is adopted to another document.

Along with this change, I also introduced symbols for the various internal properties to keep them more "internal" and not easily changed.

Introduced a new flag called `__forgeFlags__useConstructableStyleSheets` that allows developers to disable adopting stylesheet instances into shadow roots and instead force the usage of `<style>` tags.
