### PR TITLE
fix(readoptStyles): only attempt to readopt constructed stylesheets if the element instance has an `ownerDocument.defaultView` value set

### DIFF
--- a/src/custom-elements/component-utils.ts
+++ b/src/custom-elements/component-utils.ts
@@ -218,22 +218,21 @@ export function setShadowStyles<T extends HTMLElement>(componentInstance: T, sty
 }
 
 /**
- * Reapplies styles to the shadow root of the provided element instance. This function was
+ * Re-applies styles to the shadow root of the provided element instance. This function is
  * intended to be called after an element has been adopted by a new document to reconstruct the
- * adopted stylesheet instances within the context of the new document.
+ * adopted stylesheet instances within the context (view) of the new document.
  * 
  * @param componentInstance The component instance to reapply styles to.
  */
 export function readoptStyles<T extends HTMLElement>(componentInstance: T): void {
   if (!supportsConstructableStyleSheets ||
       !componentInstance.shadowRoot ||
-      !componentInstance.constructor[CUSTOM_ELEMENT_CSS_PROPERTY]) {
+      !componentInstance.constructor[CUSTOM_ELEMENT_CSS_PROPERTY] ||
+      !componentInstance.ownerDocument.defaultView) {
     return;
   }
-  const cssText = componentInstance.constructor[CUSTOM_ELEMENT_CSS_PROPERTY];
-  const context = componentInstance.ownerDocument.defaultView ?? window;
-  const sheet = new context.CSSStyleSheet();
-  sheet.replaceSync(cssText);
+  const sheet = new componentInstance.ownerDocument.defaultView.CSSStyleSheet();
+  sheet.replaceSync(componentInstance.constructor[CUSTOM_ELEMENT_CSS_PROPERTY]);
   componentInstance.shadowRoot.adoptedStyleSheets = [sheet];
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: N
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? N

## Describe the new behavior?
This change ensures that the provided element instance has an `ownerDocument.defaultView` set to truthy value before attempting to recreate the `CSSStyleSheet` instance for the element.

We no longer default to `window` if `componentInstance.ownerDocument.defaultView` is `null` because if it is `null` then we assume the `CSSStyleSheet` instance was created against a detached `document` such as an in-memory `<template>` element.
