### PR TITLE
feat(component-utils): cache parsed templates to optimize rendering

### DIFF
--- a/src/custom-elements/constants.ts
+++ b/src/custom-elements/constants.ts
@@ -1,5 +1,6 @@
 export const CUSTOM_ELEMENT_NAME_PROPERTY = Symbol('Forge custom element tag name');
 export const CUSTOM_ELEMENT_DEPENDENCIES_PROPERTY = Symbol('Forge custom element dependencies');
+export const CUSTOM_ELEMENT_TEMPLATE_PROPERTY = Symbol('Forge custom element parsed template');
 
 export const CUSTOM_ELEMENT_CSS_PROPERTY = Symbol('Forge custom element CSS text');
 export const CUSTOM_ELEMENT_STYLESHEETS_PROPERTY = Symbol('Forge custom element CSSStyleSheet instances');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: N
- Docs have been added / updated: Y
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
Following the pattern of stylesheet caching , ensuring that template strings are only parsed to HTML once and then stored on the constructor and reused.  Results in significantly faster repeat renders.  

## Additional information
<!-- Add any other context about the change here. -->
