### PR TITLE
feat(component-utils): add dedicated function to check for a registered custom element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,6 @@
         "rimraf": "^5.0.7",
         "sinon": "^18.0.0",
         "typescript": "~5.4.5"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@75lb/deep-merge": {

--- a/src/custom-elements/component-utils.ts
+++ b/src/custom-elements/component-utils.ts
@@ -33,10 +33,18 @@ export function defineCustomElements(components: any[]): void {
  * @param ctor The custom element constructor.
  */
 export function tryDefine(name: string, ctor: CustomElementConstructor, options?: ElementDefinitionOptions | undefined): void {
-  if (window?.customElements?.get(name)) {
+  if (hasDefinedCustomElement(name)) {
     return;
   }
   window.customElements.define(name, ctor, options);
+}
+
+/**
+ * Checks to see if the custom element is defined in the registry.
+ * @param name The name of the custom element to query the registry with.
+ */
+export function hasDefinedCustomElement(name: string): boolean {
+  return window?.customElements?.get(name) !== undefined;
 }
 
 /**

--- a/test/component-utils.test.ts
+++ b/test/component-utils.test.ts
@@ -1,7 +1,26 @@
 import { expect } from '@esm-bundle/chai';
-import { getClosestShadowRoot } from '../src/custom-elements/component-utils';
+import { defineCustomElement, getClosestShadowRoot, hasDefinedCustomElement } from '../src/custom-elements/component-utils';
+import { CUSTOM_ELEMENT_NAME_PROPERTY } from '../src/custom-elements/constants';
 
 describe('ComponentUtils', () => {
+  describe('hasDefinedCustomElement', () => {
+  
+    class TestCustomElement extends HTMLElement {
+      constructor() {
+        super();
+      }
+    }
+
+    it('should return true if custom element is defined', () => {
+      window.customElements.define('test-component-that-returns-true-when-checked', TestCustomElement);
+      expect(hasDefinedCustomElement('test-component-that-returns-true-when-checked')).to.be.true;
+    });
+
+    it('should return false if custom element is not defined', () => {
+      expect(hasDefinedCustomElement('test-component-that-returns-false-when-checked')).to.be.false;
+    });
+  });
+
   describe('getClosestShadowRoot', () => {
     let lightElement: HTMLElement;
     let shadowHostElement: HTMLElement;


### PR DESCRIPTION
Looking to add a dedicated function that checks for the existence of custom elements in the custom element registry.